### PR TITLE
Model Generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,18 +172,22 @@ name = "sw4rm-rs"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
  "regex",
  "semver",
  "serde",
  "serde_json",
  "serde_yaml",
+ "syn",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rust-numerals"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66422db5b68622712db06379057dcf3887cc1d3d7cacd0fb37c953cd87e82ed6"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,11 +186,13 @@ dependencies = [
 name = "sw4rm-rs"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "lazy_static",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
+ "rust-numerals",
  "semver",
  "serde",
  "serde_json",
@@ -199,6 +216,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ syn = { version = "2.0.50", features = ["full"] }
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
 prettyplease = "0.2.16"
+rust-numerals = "0.1.0"
+convert_case = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ serde_yaml = "0.9.31"
 lazy_static = "1.4.0"
 regex = "1.10.3"
 semver = { version = "1.0.22", features = ["serde"] }
+syn = { version = "2.0.50", features = ["full"] }
+proc-macro2 = "1.0.78"
+quote = "1.0.35"
+prettyplease = "0.2.16"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ in one simple model, and a way to generate models through a cargo command or in 
 ### Roadmap
 - [x] Cross-Spec support for v2 and v3
 - [ ] Parse and create Rust models using `syn`
+  - [x] Unoptimized parsing
+  - [ ] Create mod file
+  - [ ] Write files
+  - [ ] Types imports
 - [ ] Parse and create Rust apis using `syn`
   - [ ] Allow the user to specify what framework to utilize underneath
   - [ ] Allow the user to specify other options, including additional traits to derive on models

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -1,0 +1,134 @@
+#![allow(dead_code, unused)]
+
+use std::collections::HashMap;
+use proc_macro2::TokenStream;
+use syn::*;
+use syn::__private::Span;
+use syn::punctuated::Punctuated;
+use syn::token::{Bracket, Paren, PathSep, Pub, Struct};
+
+use crate::models::{
+    *, shared::*, openapi_v2::*, openapi_v3_0::*,
+};
+
+#[derive(Debug)]
+pub enum GenerationError {
+
+}
+
+pub fn parse_spec(spec: Spec) -> std::result::Result<HashMap<String, File>, GenerationError> {
+    let models = spec.schemas();
+    let models_resolved = models.iter()
+        .map(|(file_name, schema_item)| (file_name, schema_item.resolve(&spec).unwrap()))
+        .collect();
+
+    let files = parse_files(&spec, models_resolved);
+    Ok(files)
+}
+
+pub fn parse_files(
+    spec: &Spec,
+    file_items: HashMap<&String, Schema>,
+) -> HashMap<String, File> {
+    file_items.into_iter()
+        .map(|(file_name, schema)| (file_name.clone(), parse_file(spec, &file_name, schema)))
+        .collect()
+}
+
+pub fn parse_file(
+    spec: &Spec,
+    file_name: &String,
+    schema: Schema,
+) -> File {
+    let items = vec![parse_item(spec, file_name, schema)];
+
+    File {
+        items,
+        attrs: Vec::default(),
+        shebang: None,
+    }
+}
+
+pub fn parse_item(
+    spec: &Spec,
+    file_name: &String,
+    schema: Schema,
+) -> Item {
+    let ident = Ident::new(schema.title.unwrap_or(file_name.clone()).as_str(), Span::call_site());
+    let attrs = parse_struct_attrs(schema.description);
+    let fields = Fields::Unit;
+
+    Item::Struct(ItemStruct {
+        ident, attrs, fields,
+        vis: Visibility::Public(Token![pub](Span::call_site())),
+        semi_token: None,
+        struct_token: Token![struct](Span::call_site()),
+        generics: Generics::default(),
+    })
+}
+
+pub fn parse_struct_attrs(
+    description: Option<String>,
+) -> Vec<Attribute> {
+    let mut attrs = Vec::new();
+
+    if let Some(description) = description {
+        let description = format!(" {description}");
+
+        let mut comment_segments = Punctuated::new();
+        comment_segments.push(PathSegment { ident: Ident::new("doc", Span::call_site()), arguments: PathArguments::None });
+        let comment_expression = ExprLit {
+            attrs: Vec::default(),
+            lit: Lit::Str(LitStr::new(description.as_str(), Span::call_site()))
+        };
+        let comment_meta = MetaNameValue {
+            path: Path { leading_colon: None, segments: comment_segments },
+            eq_token: Token![=](Span::call_site()),
+            value: Expr::Lit(comment_expression),
+        };
+        let comment_attr = Attribute {
+            pound_token: Token![#](Span::call_site()),
+            style: AttrStyle::Outer,
+            bracket_token: Bracket::default(),
+            meta: Meta::NameValue(comment_meta)
+        };
+
+        attrs.push(comment_attr);
+    }
+
+
+    let mut derive_segments = Punctuated::new();
+    derive_segments.push(PathSegment { ident: Ident::new("derive", Span::call_site()), arguments: PathArguments::None });
+    let derive_token_stream = quote::quote! {
+        Debug, Serialize, Deserialize, Default, Clone, PartialEq
+    };
+    let derive_meta = MetaList {
+        path: Path { leading_colon: None, segments: derive_segments },
+        delimiter: MacroDelimiter::Paren(Paren::default()),
+        tokens: derive_token_stream,
+    };
+    let derive_attr = Attribute {
+        pound_token: Token![#](Span::call_site()),
+        style: AttrStyle::Outer,
+        bracket_token: Bracket::default(),
+        meta: Meta::List(derive_meta),
+    };
+
+    attrs.push(derive_attr);
+
+    attrs
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parsing() {
+        let spec = crate::from_path("./resources/riot-openapi-3.0.0.json").unwrap();
+        let files = super::parse_spec(spec).unwrap();
+
+        for (_, file) in files {
+            let file_str = prettyplease::unparse(&file);
+            println!("{file_str}")
+        }
+    }
+}

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -468,13 +468,23 @@ fn get_type(
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_parsing() {
+    fn test_parsing_yaml_v2() {
+        let spec = crate::from_path("./resources/swagger_2_0.yaml").unwrap();
+        _ = super::parse_spec(spec).unwrap();
+    }
+    #[test]
+    fn test_parsing_json_v2() {
+        let spec = crate::from_path("./resources/riot-swaggerspec-2.0.json").unwrap();
+        _ = super::parse_spec(spec).unwrap();
+    }
+    #[test]
+    fn test_parsing_yaml_v3() {
+        let spec = crate::from_path("./resources/openapi_3_0.yaml").unwrap();
+        _ = super::parse_spec(spec).unwrap();
+    }
+    #[test]
+    fn test_parsing_json_v3() {
         let spec = crate::from_path("./resources/riot-openapi-3.0.0.json").unwrap();
-        let files = super::parse_spec(spec).unwrap();
-
-        for (_, file) in files {
-            let file_str = prettyplease::unparse(&file);
-            println!("{file_str}")
-        }
+        _ = super::parse_spec(spec).unwrap();
     }
 }

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -1,15 +1,34 @@
 #![allow(dead_code, unused)]
 
 use std::collections::HashMap;
+use convert_case::{Case, Casing};
+use lazy_static::lazy_static;
 use proc_macro2::TokenStream;
+use quote::ToTokens;
+use regex::{Captures, Regex};
 use syn::*;
 use syn::__private::Span;
 use syn::punctuated::Punctuated;
-use syn::token::{Bracket, Paren, PathSep, Pub, Struct};
+use syn::token::{Brace, Bracket, Comma, Paren, PathSep, Pub, Struct};
 
 use crate::models::{
     *, shared::*, openapi_v2::*, openapi_v3_0::*,
 };
+
+lazy_static! {
+    static ref HAS_NUMBER_REGEX: Regex = Regex::new(
+        r"\d+",
+    ).unwrap();
+    static ref NUMBER_REGEX: Regex = Regex::new(
+        r"^(?<number>\d+)",
+    ).unwrap();
+    static ref TYPE_REGEX: Regex = Regex::new(
+        r"^(?<item_type>type)$",
+    ).unwrap();
+    static ref MATCH_REGEX: Regex = Regex::new(
+        r"^(?<item_match>match)$",
+    ).unwrap();
+}
 
 #[derive(Debug)]
 pub enum GenerationError {
@@ -40,7 +59,26 @@ pub fn parse_file(
     file_name: &String,
     schema: Schema,
 ) -> File {
-    let items = vec![parse_item(spec, file_name, schema)];
+    let use_hashmap_item = ItemUse {
+        attrs: Vec::default(),
+        vis: Visibility::Inherited,
+        use_token: Token![use](Span::call_site()),
+        leading_colon: None,
+        semi_token: Token![;](Span::call_site()),
+        tree: UseTree::Path(UsePath {
+            ident: Ident::new("std", Span::call_site()),
+            colon2_token: Token![::](Span::call_site()),
+            tree: Box::new(UseTree::Path(UsePath {
+                ident: Ident::new("collections", Span::call_site()),
+                colon2_token: Token![::](Span::call_site()),
+                tree: Box::new(UseTree::Name(UseName {
+                    ident: Ident::new("HashMap", Span::call_site())
+                }))
+            }))
+        })
+    };
+
+    let items = vec![Item::Use(use_hashmap_item), parse_item(spec, file_name, schema)];
 
     File {
         items,
@@ -54,12 +92,16 @@ pub fn parse_item(
     file_name: &String,
     schema: Schema,
 ) -> Item {
-    let ident = Ident::new(schema.title.unwrap_or(file_name.clone()).as_str(), Span::call_site());
-    let attrs = parse_struct_attrs(schema.description);
-    let fields = Fields::Unit;
+    let ident = Ident::new(schema.title.clone().unwrap_or(file_name.clone()).as_str(), Span::call_site());
+    let attrs = parse_struct_attrs(schema.description.clone());
+    let fields = FieldsNamed {
+        named: parse_struct_fields(spec, &schema),
+        brace_token: Brace::default(),
+    };
 
     Item::Struct(ItemStruct {
-        ident, attrs, fields,
+        ident, attrs,
+        fields: Fields::Named(fields),
         vis: Visibility::Public(Token![pub](Span::call_site())),
         semi_token: None,
         struct_token: Token![struct](Span::call_site()),
@@ -92,10 +134,8 @@ pub fn parse_struct_attrs(
             bracket_token: Bracket::default(),
             meta: Meta::NameValue(comment_meta)
         };
-
         attrs.push(comment_attr);
     }
-
 
     let mut derive_segments = Punctuated::new();
     derive_segments.push(PathSegment { ident: Ident::new("derive", Span::call_site()), arguments: PathArguments::None });
@@ -113,10 +153,316 @@ pub fn parse_struct_attrs(
         bracket_token: Bracket::default(),
         meta: Meta::List(derive_meta),
     };
-
     attrs.push(derive_attr);
 
+    let mut default_segments = Punctuated::new();
+    default_segments.push(PathSegment { ident: Ident::new("default", Span::call_site()), arguments: PathArguments::None });
+    let default_meta = Path {
+        leading_colon: None,
+        segments: default_segments,
+    };
+
+    let mut rename_segments = Punctuated::new();
+    rename_segments.push(PathSegment { ident: Ident::new("rename_all", Span::call_site()), arguments: PathArguments::None });
+    let rename_expression = ExprLit {
+        attrs: Vec::default(),
+        lit: Lit::Str(LitStr::new("camelCase", Span::call_site()))
+    };
+    let rename_meta = MetaNameValue {
+        path: Path { leading_colon: None, segments: rename_segments },
+        eq_token: Token![=](Span::call_site()),
+        value: Expr::Lit(rename_expression)
+    };
+
+    let mut serde_attr_segments: Punctuated<TokenStream, Comma> = Punctuated::new();
+    serde_attr_segments.push(default_meta.to_token_stream());
+    serde_attr_segments.push(rename_meta.to_token_stream());
+
+    let mut serde_segments = Punctuated::new();
+    serde_segments.push(PathSegment { ident: Ident::new("serde", Span::call_site()), arguments: PathArguments::None });
+    let serde_meta = MetaList {
+        path: Path { leading_colon: None, segments: serde_segments },
+        delimiter: MacroDelimiter::Paren(Paren::default()),
+        tokens: serde_attr_segments.to_token_stream()
+    };
+    let serde_attr = Attribute {
+        pound_token: Token![#](Span::call_site()),
+        style: AttrStyle::Outer,
+        bracket_token: Bracket::default(),
+        meta: Meta::List(serde_meta),
+    };
+
+    attrs.push(serde_attr);
+
     attrs
+}
+
+pub fn parse_struct_fields(
+    spec: &Spec,
+    schema: &Schema,
+) -> Punctuated<Field, Comma> {
+    schema.properties.iter()
+        .map(|(object_name, object_reference)| (object_name, object_reference.resolve(spec).unwrap()))
+        .map(|(object_name, schema)| parse_struct_field(spec, object_name, schema))
+        .collect::<Punctuated<_, Comma>>()
+}
+
+pub fn parse_struct_field(
+    spec: &Spec,
+    property_name: &String,
+    schema: Box<Schema>,
+) -> Field {
+    let binding = schema.clone();
+    let schema_ref = binding.as_ref();
+
+    let (ident, needs_rename) = parse_field_ident(property_name);
+    let attrs = parse_field_attrs(&schema.description, property_name, needs_rename);
+
+    let required_fields = schema.required.clone();
+
+    let path_segments = recursive_field_type(
+        spec,
+        schema_ref,
+        !required_fields.contains(&property_name),
+        schema.schema_type.eq(&Some(SchemaType::Array)),
+        schema.title,
+        schema.schema_type
+    );
+    let path = TypePath {
+        qself: None,
+        path: Path { leading_colon: None, segments: path_segments }
+    };
+
+    Field {
+        attrs,
+        ident: Some(ident),
+        vis: Visibility::Public(Token![pub](Span::call_site())),
+        mutability: FieldMutability::None,
+        colon_token: None,
+        ty: Type::Path(path),
+    }
+}
+
+pub fn parse_field_ident(
+    item_name: &String,
+) -> (Ident, bool) {
+    let cased = item_name.clone().to_case(Case::Snake);
+    let number_checked = NUMBER_REGEX.replace(&cased.as_str(), |cap: &Captures| {
+        let number = cap["number"].parse::<i64>().unwrap();
+        rust_numerals::number_to_cardinal(number)
+    });
+    let type_checked = TYPE_REGEX.replace(&number_checked, "kind");
+    let match_checked = MATCH_REGEX.replace(&type_checked, "match_item");
+
+    let ident = Ident::new(&match_checked, Span::call_site());
+    let needs_rename = cased.ne(&match_checked) || HAS_NUMBER_REGEX.is_match(item_name);
+
+    (ident, needs_rename)
+}
+
+pub fn parse_field_attrs(
+    description: &Option<String>,
+    field_name: &String,
+    needs_rename: bool,
+) -> Vec<Attribute> {
+    let mut attrs = Vec::new();
+
+    if let Some(description) = description {
+        let description = format!(" {description}");
+
+        let mut comment_segments = Punctuated::new();
+        comment_segments.push(PathSegment { ident: Ident::new("doc", Span::call_site()), arguments: PathArguments::None });
+        let comment_expression = ExprLit {
+            attrs: Vec::default(),
+            lit: Lit::Str(LitStr::new(description.as_str(), Span::call_site()))
+        };
+        let comment_meta = MetaNameValue {
+            path: Path { leading_colon: None, segments: comment_segments },
+            eq_token: Token![=](Span::call_site()),
+            value: Expr::Lit(comment_expression),
+        };
+        let comment_attr = Attribute {
+            pound_token: Token![#](Span::call_site()),
+            style: AttrStyle::Outer,
+            bracket_token: Bracket::default(),
+            meta: Meta::NameValue(comment_meta)
+        };
+        attrs.push(comment_attr);
+    }
+
+    if needs_rename {
+        let mut rename_segments = Punctuated::new();
+        rename_segments.push(PathSegment { ident: Ident::new("rename", Span::call_site()), arguments: PathArguments::None });
+        let rename_expression = ExprLit {
+            attrs: Vec::default(),
+            lit: Lit::Str(LitStr::new(field_name, Span::call_site()))
+        };
+        let rename_meta = MetaNameValue {
+            path: Path { leading_colon: None, segments: rename_segments },
+            eq_token: Token![=](Span::call_site()),
+            value: Expr::Lit(rename_expression)
+        };
+        let mut serde_segments = Punctuated::new();
+        serde_segments.push(PathSegment { ident: Ident::new("serde", Span::call_site()), arguments: PathArguments::None });
+        let serde_meta = MetaList {
+            path: Path { leading_colon: None, segments: serde_segments },
+            delimiter: MacroDelimiter::Paren(Paren::default()),
+            tokens: rename_meta.to_token_stream()
+        };
+        let serde_attr = Attribute {
+            pound_token: Token![#](Span::call_site()),
+            style: AttrStyle::Outer,
+            bracket_token: Bracket::default(),
+            meta: Meta::List(serde_meta),
+        };
+        attrs.push(serde_attr);
+    }
+
+    attrs
+}
+
+fn recursive_field_type(
+    spec: &Spec,
+    schema: &Schema,
+    is_optional: bool,
+    is_array: bool,
+    field_title: Option<String>,
+    field_type: Option<SchemaType>,
+) -> Punctuated<PathSegment, PathSep> {
+    if is_optional {
+        let child_segments = recursive_field_type(spec, schema, false, is_array, field_title, field_type);
+
+        let mut args: Vec<GenericArgument> = Vec::new();
+        args.push(GenericArgument::Type(Type::Path(
+            TypePath { qself: None, path: Path { leading_colon: None, segments: child_segments } }
+        )));
+
+        let generic_arguments = AngleBracketedGenericArguments {
+            args: args.into_iter().collect(),
+            colon2_token: None,
+            lt_token: Token![<](Span::call_site()),
+            gt_token: Token![>](Span::call_site()),
+        };
+
+        let ident = Ident::new("Option", Span::call_site());
+
+        let mut final_segment: Vec<PathSegment> = Vec::new();
+        final_segment.push(
+            PathSegment { ident, arguments: PathArguments::AngleBracketed(generic_arguments) }
+        );
+
+        return final_segment.into_iter().collect();
+    }
+
+    if is_array {
+        let child_segments = recursive_field_type(spec, schema, is_optional, false, field_title, field_type);
+
+        let mut args: Vec<GenericArgument> = Vec::new();
+        args.push(GenericArgument::Type(Type::Path(
+            TypePath { qself: None, path: Path { leading_colon: None, segments: child_segments } }
+        )));
+
+        let generic_arguments = AngleBracketedGenericArguments {
+            args: args.into_iter().collect(),
+            colon2_token: None,
+            lt_token: Token![<](Span::call_site()),
+            gt_token: Token![>](Span::call_site()),
+        };
+
+        let ident = Ident::new("Vec", Span::call_site());
+
+        let mut final_segment: Vec<PathSegment> = Vec::new();
+        final_segment.push(
+            PathSegment { ident, arguments: PathArguments::AngleBracketed(generic_arguments) }
+        );
+
+        return final_segment.into_iter().collect();
+    }
+
+    // TODO: this whole block needs to be optimized
+    if schema.schema_type.eq(&Some(SchemaType::Object)) && (schema.title.is_none() || schema.clone().title.is_some_and(|t| t.is_empty())) {
+        let mut string_arguments: Vec<PathSegment> = Vec::new();
+        string_arguments.push(PathSegment {
+            ident: Ident::new("String", Span::call_site()),
+            arguments: PathArguments::None,
+        });
+
+        let mut json_arguments: Vec<PathSegment> = Vec::new();
+        json_arguments.push(PathSegment {
+            ident: Ident::new("serde_json", Span::call_site()),
+            arguments: PathArguments::None,
+        });
+        json_arguments.push(PathSegment {
+            ident: Ident::new("Value", Span::call_site()),
+            arguments: PathArguments::None,
+        });
+
+        let mut generic_args: Vec<GenericArgument> = Vec::new();
+        generic_args.push(GenericArgument::Type(Type::Path(
+            TypePath { qself: None, path: Path { leading_colon: None, segments: string_arguments.into_iter().collect() } }
+        )));
+        generic_args.push(GenericArgument::Type(Type::Path(
+            TypePath { qself: None, path: Path { leading_colon: None, segments: json_arguments.into_iter().collect() } }
+        )));
+
+        let generic_arguments = AngleBracketedGenericArguments {
+            args: generic_args.into_iter().collect(),
+            colon2_token: None,
+            lt_token: Token![<](Span::call_site()),
+            gt_token: Token![>](Span::call_site()),
+        };
+
+        let ident = Ident::new("HashMap", Span::call_site());
+
+        let mut final_segment: Vec<PathSegment> = Vec::new();
+        final_segment.push(
+            PathSegment { ident, arguments: PathArguments::AngleBracketed(generic_arguments) }
+        );
+
+        return final_segment.into_iter().collect();
+    }
+
+    let ident_type = get_type(spec, field_title, field_type, &schema.items, &schema.additional_properties);
+
+    let mut final_segment: Vec<PathSegment> = Vec::new();
+    final_segment.push(
+        PathSegment {
+            ident: Ident::new(ident_type.as_str(), Span::call_site()),
+            arguments: PathArguments::None,
+        }
+    );
+
+    final_segment.into_iter().collect()
+}
+
+fn get_type(
+    spec: &Spec,
+    field_title: Option<String>,
+    field_type: Option<SchemaType>,
+    properties: &Option<RefOr<Box<Schema>>>,
+    additional_properties: &Option<RefOr<Box<Schema>>>,
+) -> String {
+    match field_type {
+        Some(SchemaType::Boolean) => return "bool".to_string(),
+        Some(SchemaType::Integer) => return "i64".to_string(),
+        Some(SchemaType::Number) => return "f64".to_string(),
+        Some(SchemaType::String) => return "String".to_string(),
+        Some(SchemaType::Object) if field_title.is_some() => return field_title.unwrap(),
+
+        _ => ()
+    };
+
+    if let Some(items) = properties {
+        let items = items.resolve(spec).unwrap();
+        return get_type(spec, items.title, items.schema_type, &items.items, &items.additional_properties);
+    }
+
+    if let Some(additional_items) = additional_properties {
+        let items = additional_items.resolve(spec).unwrap();
+        return get_type(spec, items.title, items.schema_type, &items.items, &items.additional_properties);
+    }
+
+    unreachable!()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod models;
 pub mod error;
-mod generation;
+pub mod generation;
 
 use std::{
     fs::File, io::Read, path::Path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod models;
 pub mod error;
+mod generation;
 
 use std::{
     fs::File, io::Read, path::Path,

--- a/src/models/reference.rs
+++ b/src/models/reference.rs
@@ -14,11 +14,11 @@ pub trait Resolvable: Clone + Sized {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum RefOr<T> where T: Resolvable {
-    Item(T),
     Reference {
         #[serde(rename = "$ref")]
         reference_path: String,
-    }
+    },
+    Item(T),
 }
 impl<T> RefOr<T> where T: Resolvable {
     pub fn resolve(&self, spec: &Spec) -> Result<T, ResolveError> {

--- a/src/models/reference.rs
+++ b/src/models/reference.rs
@@ -24,7 +24,7 @@ impl<T> RefOr<T> where T: Resolvable {
     pub fn resolve(&self, spec: &Spec) -> Result<T, ResolveError> {
         match self {
             Self::Item(item) => Ok(item.clone()),
-            Self::Reference { reference_path } => T::resolve(spec, reference_path)
+            Self::Reference { reference_path } => T::resolve(spec, reference_path),
         }
     }
 }

--- a/src/models/shared/schema.rs
+++ b/src/models/shared/schema.rs
@@ -131,6 +131,7 @@ impl Resolvable for Schema {
 pub enum SchemaType {
     Array,
     Boolean,
+    File,
     Integer,
     Number,
     Object,

--- a/src/models/shared/schema.rs
+++ b/src/models/shared/schema.rs
@@ -60,7 +60,7 @@ pub struct Schema {
     #[serde(rename = "enum", skip_serializing_if = "Vec::is_empty")]
     pub enum_values: Vec<Value>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub schema_type: Option<String>,
+    pub schema_type: Option<SchemaType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<RefOr<Box<Self>>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -124,4 +124,18 @@ impl Resolvable for Schema {
             _ => Err(ResolveError::UnknownPathError(path)),
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum SchemaType {
+    Array,
+    Boolean,
+    Integer,
+    Number,
+    Object,
+    String,
+}
+impl Default for SchemaType {
+    fn default() -> Self { Self::Object }
 }

--- a/src/models/spec.rs
+++ b/src/models/spec.rs
@@ -84,4 +84,12 @@ impl Spec {
         let version = VersionReq::parse(version).unwrap();
         version.matches(&spec_version)
     }
+
+    pub fn schemas(&self) -> HashMap<String, RefOr<Schema>> {
+        self.components
+            .as_ref()
+            .map(|c| c.schemas.clone())
+            .unwrap_or(self.definitions.clone())
+            .clone()
+    }
 }


### PR DESCRIPTION
First swing at generating models. At present, output a hashmap of `filename: syn::File` that can be `prettyplease::unparse`d for convenience.

This generation is severely unoptimized, does not take external type imports into account, does not generate a mod file, and must be run in a build script. This generation _does_ generate serde attributes, a set number of derive attributes, and doc comments.