### PR TITLE
adding cargo binary for generating models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +138,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -241,8 +341,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "sw4rm-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "regex",
@@ -254,8 +360,9 @@ dependencies = [
 
 [[package]]
 name = "sw4rm-rs-cargo-generation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "clap",
  "log",
  "pretty_env_logger",
  "sw4rm-rs",
@@ -264,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "sw4rm-rs-generation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "convert_case",
  "lazy_static",
@@ -314,6 +421,12 @@ name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "winapi"

--- a/cargo-openapi-generator/Cargo.toml
+++ b/cargo-openapi-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw4rm-rs-cargo-generation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["MatrixSenpai <math.matrix@icloud.com>"]
 description = "A binary to handle generation of rust models & apis from OpenAPI v2, v3, and v3.1 specs working through cargo or on command line"
@@ -11,3 +11,4 @@ sw4rm-rs = { path = "../core" }
 sw4rm-rs-generation = { path = "../generator" }
 log = "0.4"
 pretty_env_logger = "0.5"
+clap = { version = "4.5.1", features = ["derive"] }

--- a/cargo-openapi-generator/src/main.rs
+++ b/cargo-openapi-generator/src/main.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+use clap::Parser;
+use sw4rm_rs_generation::{read_parse_write_single_spec, read_parse_write_multi_spec};
+
+fn main() {
+    let args = Args::parse();
+
+    for item in args.input_dir.iter() {
+        if item.is_dir() {
+            read_parse_write_multi_spec(item).unwrap()
+        } else {
+            read_parse_write_single_spec(item).unwrap()
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(num_args = 0..)]
+    input_dir: Vec<PathBuf>,
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw4rm-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["MatrixSenpai <math.matrix@icloud.com>"]
 description = "A crate to handle OpenAPI v2, v3, and v3.1 specs"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw4rm-rs-generation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["MatrixSenpai <math.matrix@icloud.com>"]
 description = "A crate to handle generation of rust models & apis from OpenAPI v2, v3, and v3.1 specs"


### PR DESCRIPTION
This pr adds a simple clap-powered cargo script to run against a set of files or directories as desired by the user